### PR TITLE
Fix compatibility with Firefox for Android

### DIFF
--- a/LifeCounter/CHANGELOG.txt
+++ b/LifeCounter/CHANGELOG.txt
@@ -1,3 +1,8 @@
+LifeCounter vX.X.X changelog:
+ * Fixed failing startup in Firefox for Android
+
+---
+
 LifeCounter v4.10.6 changelog:
  * Added buttons for controlling game time tracker
  * Score history enabled by default

--- a/LifeCounter/app/src/lang.js
+++ b/LifeCounter/app/src/lang.js
@@ -73,9 +73,7 @@
 }
 
 'static'; function SetLanguageById(id) {
-    [
-        SetLanguageCzech,
-        SetLanguageEnglish,
-    ][id]();
+    if (id == 0) SetLanguageCzech();
+    else SetLanguageEnglish();
     ClearFontSizeCache();
 }

--- a/LifeCounter/knowledge-base.md
+++ b/LifeCounter/knowledge-base.md
@@ -9,3 +9,15 @@
 ```
 
 Must be triggered by a user generated, short lived event.
+
+## Debugging mobile
+
+Instead of remote debugging, following workaround on `app.min.js` can be used:
+
+```js
+try {
+    var code = `original app.min.js contents`;
+} catch (e) {
+    alert(e.message);
+}
+```


### PR DESCRIPTION
Implementation of `SetLanguageById` could not be properly executed by Firefox for Android